### PR TITLE
Add loss.out parsing test

### DIFF
--- a/src/NepTrainKit/core/io/utils.py
+++ b/src/NepTrainKit/core/io/utils.py
@@ -97,3 +97,38 @@ def get_nep_type(file_path):
 
     return model_type
 
+
+def parse_loss_file(file_path):
+    """Parse a ``loss.out`` style file.
+
+    The file is expected to contain at least two columns where the first
+    column is the step index and the second column is the loss value. If the
+    file contains only a single column of losses, the step index will be
+    generated sequentially starting from zero.
+
+    Parameters
+    ----------
+    file_path : str or Path
+        Path to the ``loss.out`` file.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        A tuple ``(steps, losses)`` with ``dtype`` ``int`` and ``float``
+        respectively. Empty arrays are returned when the file does not exist.
+    """
+
+    logger.info(f"Reading loss file: {file_path}")
+    if not os.path.exists(file_path):
+        return np.array([]), np.array([])
+
+    data = np.loadtxt(file_path)
+    if data.ndim == 1:
+        steps = np.arange(data.shape[0], dtype=int)
+        losses = data.astype(float)
+    else:
+        steps = data[:, 0].astype(int)
+        losses = data[:, 1].astype(float)
+
+    return steps, losses
+

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,14 @@
+import numpy as np
+from pathlib import Path
+from NepTrainKit.core.io.utils import parse_loss_file
+
+
+def test_parse_loss(tmp_path: Path):
+    sample = """0 1.0\n1 0.8\n2 0.6\n3 0.5\n"""
+    loss_file = tmp_path / "loss.out"
+    loss_file.write_text(sample)
+
+    steps, losses = parse_loss_file(loss_file)
+
+    np.testing.assert_array_equal(steps, np.array([0, 1, 2, 3]))
+    np.testing.assert_allclose(losses, np.array([1.0, 0.8, 0.6, 0.5]))


### PR DESCRIPTION
## Summary
- implement `parse_loss_file` helper in `utils.py`
- test parsing of a sample `loss.out` in new `test_train.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*