### PR TITLE
Add training documentation

### DIFF
--- a/docs/source/module/index.rst
+++ b/docs/source/module/index.rst
@@ -6,4 +6,5 @@ module
 
    NEP dataset display <NEP-dataset-display>
    Make dataset <make-dataset>
+   Train NEP <train-nep>
 

--- a/docs/source/module/train-nep.md
+++ b/docs/source/module/train-nep.md
@@ -1,0 +1,10 @@
+# Train NEP
+
+## 1. Using the Training Page
+The training page provides a streamlined workflow for launching NEP model training directly from the GUI.  After selecting a dataset you can configure basic parameters such as the number of steps and output directory.  Press **Start** to begin training; progress is shown in the log area and you can pause or stop the job at any time.
+
+## 2. SSH Options
+Training can run on remote machines via SSH.  Enable the *Use SSH* option and provide the remote host, port, user name and the path to your NEP environment.  Files are transferred automatically and the remote job output is displayed in the same log window.
+
+## 3. Plotting Features
+Once training is underway the page displays real‑time plots of the energy and force errors.  You can open the plotting panel from the toolbar to review trends, zoom in on regions of interest and save the figures for later analysis.


### PR DESCRIPTION
## Summary
- document how to use the new training page, SSH mode and plotting options
- list the new doc in the module section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*