### PR TITLE
Add paramiko dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
 "numpy>=1.26.0",
 "vispy>=0.14.3",
 "ase",
-"scipy>=1.15.0"
+"scipy>=1.15.0",
+"paramiko>=2.12"
 ]
 [project.optional-dependencies]
 test = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyOpenGL==3.1.7
 vispy==0.15.2
 ase
 scipy==1.15.0
+paramiko>=2.12


### PR DESCRIPTION
## Summary
- require paramiko in requirements
- list paramiko in project dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*