### PR TITLE
Add TrainNepWidget placeholder and nav link

### DIFF
--- a/src/NepTrainKit/core/pages/__init__.py
+++ b/src/NepTrainKit/core/pages/__init__.py
@@ -6,3 +6,4 @@
 from .makedata import MakeDataWidget
 from .settings import SettingsWidget
 from .show_nep import ShowNepWidget
+from .train_nep import TrainNepWidget

--- a/src/NepTrainKit/core/pages/train_nep.py
+++ b/src/NepTrainKit/core/pages/train_nep.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+from qfluentwidgets import BodyLabel
+
+
+class TrainNepWidget(QWidget):
+    """Simple placeholder widget for NEP training."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("TrainNepWidget")
+        layout = QVBoxLayout(self)
+        layout.addWidget(BodyLabel("Train NEP Placeholder", self))
+

--- a/src/NepTrainKit/main.py
+++ b/src/NepTrainKit/main.py
@@ -77,6 +77,9 @@ class NepTrainKitMainWindow(FluentWindow):
         self.addSubInterface(self.make_data_widget,
                              QIcon(':/images/src/images/make.svg'),
                              'Make Data' )
+        self.addSubInterface(self.train_nep_widget,
+                             QIcon(':/images/src/images/run.svg'),
+                             'Train NEP')
 
         self.addSubInterface(self.setting_interface,
                              FIF.SETTING,
@@ -90,6 +93,7 @@ class NepTrainKitMainWindow(FluentWindow):
     def init_widget(self):
         self.show_nep_interface = ShowNepWidget(self)
         self.make_data_widget = MakeDataWidget(self)
+        self.train_nep_widget = TrainNepWidget(self)
 
         self.setting_interface = SettingsWidget(self)
 


### PR DESCRIPTION
## Summary
- create a basic `TrainNepWidget`
- expose `TrainNepWidget` from `core.pages`
- add the widget to `init_widget`
- register a navigation entry labelled "Train NEP"

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*