### PR TITLE
Support ranges for defect card rules

### DIFF
--- a/src/NepTrainKit/core/custom_widget/doping_rule.py
+++ b/src/NepTrainKit/core/custom_widget/doping_rule.py
@@ -15,20 +15,19 @@ from PySide6.QtWidgets import (
     QGridLayout,
     QHBoxLayout,
     QVBoxLayout,
-    QWidget, QLineEdit,
-
+    QWidget,
+    QLineEdit,
 )
 from qfluentwidgets import (
     BodyLabel,
     TransparentToolButton,
-    SpinBox,
-    DoubleSpinBox,
     FluentIcon,
     LineEdit,
     RadioButton,
     ToolTipFilter,
     ToolTipPosition,
 )
+from .input import SpinBoxUnitInputFrame
 
 
 class DopingRuleItem(QFrame):
@@ -46,13 +45,17 @@ class DopingRuleItem(QFrame):
         self.setFixedSize(300, 100)
         self.dopants_edit = QLineEdit(self)
          
-        self.concentration_spin = QLineEdit(self)
-        self.concentration_spin.setText("1")
+        self.concentration_frame = SpinBoxUnitInputFrame(self)
+        self.concentration_frame.set_input(["-", ""], 2, "float")
+        self.concentration_frame.setRange(0, 1)
+        self.concentration_frame.set_input_value([0.0, 1.0])
 
         self.concentration_botton = RadioButton("Conc", self)
         self.concentration_botton.setChecked(True)
-        self.count_spin = QLineEdit(self)
-        self.count_spin.setText("10")
+        self.count_frame = SpinBoxUnitInputFrame(self)
+        self.count_frame.set_input(["-", ""], 2, "int")
+        self.count_frame.setRange(0, 10000)
+        self.count_frame.set_input_value([1, 1])
         self.count_botton = RadioButton("Count", self)
 
         self.indices_edit = QLineEdit(self)
@@ -78,11 +81,11 @@ class DopingRuleItem(QFrame):
         self.concentration_botton.setToolTip("Use concentration")
         self.concentration_botton.installEventFilter(ToolTipFilter(self.concentration_botton, 300, ToolTipPosition.TOP))
         self.layout.addWidget(self.concentration_botton, 2, 0)
-        self.layout.addWidget(self.concentration_spin, 2, 1)
+        self.layout.addWidget(self.concentration_frame, 2, 1)
         self.count_botton.setToolTip("Use count")
         self.count_botton.installEventFilter(ToolTipFilter(self.count_botton, 300, ToolTipPosition.TOP))
         self.layout.addWidget(self.count_botton, 2, 2)
-        self.layout.addWidget(self.count_spin, 2, 3)
+        self.layout.addWidget(self.count_frame, 2, 3)
 
         self.delete_button.setToolTip("Delete rule")
         self.delete_button.installEventFilter(ToolTipFilter(self.delete_button, 300, ToolTipPosition.TOP))
@@ -115,9 +118,9 @@ class DopingRuleItem(QFrame):
         except Exception:
             logger.error(traceback.format_exc())
 
-        rule["concentration"] =float(self.concentration_spin.text().strip()) if self.concentration_spin.text().strip() else 0
+        rule["concentration"] = [float(v) for v in self.concentration_frame.get_input_value()]
 
-        rule["count"] =float(self.count_spin.text().strip()) if self.count_spin.text().strip() else 0
+        rule["count"] = [int(v) for v in self.count_frame.get_input_value()]
         rule["use"] = "concentration" if self.concentration_botton.isChecked() else "count"
         indices_text = self.indices_edit.text().strip()
         if indices_text:
@@ -136,9 +139,9 @@ class DopingRuleItem(QFrame):
         if dopants is not None:
             self.dopants_edit.setText(json.dumps(dopants))
         if "concentration" in rule:
-            self.concentration_spin.setText(str(rule["concentration"]))
+            self.concentration_frame.set_input_value(rule["concentration"])
         if "count" in rule:
-            self.count_spin.setText(str(rule["count"]))
+            self.count_frame.set_input_value(rule["count"])
         if "group" in rule:
             self.indices_edit.setText(",".join(str(i) for i in rule["group"]))
         if "use" in  rule:

--- a/src/NepTrainKit/core/custom_widget/vacancy_rule.py
+++ b/src/NepTrainKit/core/custom_widget/vacancy_rule.py
@@ -21,6 +21,7 @@ from qfluentwidgets import (
     ToolTipFilter,
     ToolTipPosition,
 )
+from .input import SpinBoxUnitInputFrame
 
 
 class VacancyRuleItem(QFrame):
@@ -36,8 +37,10 @@ class VacancyRuleItem(QFrame):
         self.element_edit = QLineEdit(self)
         self.element_edit.setPlaceholderText("Cs")
         self.group_edit = QLineEdit(self)
-        self.count_edit = QLineEdit(self)
-        self.count_edit.setText("1")
+        self.count_frame = SpinBoxUnitInputFrame(self)
+        self.count_frame.set_input(["-", ""], 2, "int")
+        self.count_frame.setRange(0, 10000)
+        self.count_frame.set_input_value([1, 1])
 
         self.delete_button = TransparentToolButton(QIcon(":/images/src/images/delete.svg"), self)
         self.delete_button.clicked.connect(self._delete_self)
@@ -57,7 +60,7 @@ class VacancyRuleItem(QFrame):
         self.layout.addWidget(self.group_label, 0, 2)
         self.layout.addWidget(self.group_edit, 0, 3)
         self.layout.addWidget(self.count_label, 1, 0)
-        self.layout.addWidget(self.count_edit, 1, 1)
+        self.layout.addWidget(self.count_frame, 1, 1)
         self.layout.addWidget(self.delete_button, 0, 4, 2, 1)
 
     def _delete_self(self) -> None:
@@ -69,12 +72,7 @@ class VacancyRuleItem(QFrame):
         element = self.element_edit.text().strip()
         if element:
             rule["element"] = element
-        count_text = self.count_edit.text().strip()
-        if count_text:
-            try:
-                rule["count"] = int(float(count_text))
-            except Exception:
-                pass
+        rule["count"] = [int(v) for v in self.count_frame.get_input_value()]
         groups = self.group_edit.text().strip()
         if groups:
             rule["group"] = [g.strip() for g in groups.split(",") if g.strip()]
@@ -85,7 +83,7 @@ class VacancyRuleItem(QFrame):
             return
         self.element_edit.setText(str(rule.get("element", "")))
         if "count" in rule:
-            self.count_edit.setText(str(rule["count"]))
+            self.count_frame.set_input_value(rule["count"])
         if "group" in rule:
             self.group_edit.setText(",".join(str(i) for i in rule["group"]))
 

--- a/src/NepTrainKit/core/views/cards.py
+++ b/src/NepTrainKit/core/views/cards.py
@@ -924,9 +924,12 @@ class RandomDopingCard(MakeDataCard):
                     continue
 
                 if "concentration" == rule["use"]:
-                    doping_num = max(1, int(len(candidate_indices) * float(rule["concentration"])))
+                    conc_min, conc_max = rule.get("concentration", [0.0, 1.0])
+                    conc = np.random.uniform(float(conc_min), float(conc_max))
+                    doping_num = max(1, int(len(candidate_indices) * conc))
                 elif "count" == rule["use"]:
-                    doping_num = int(rule["count"])
+                    count_min, count_max = rule.get("count", [1, 1])
+                    doping_num = np.random.randint(int(count_min), int(count_max) + 1)
                 else:
                     doping_num = len(candidate_indices)
 
@@ -1017,8 +1020,8 @@ class RandomVacancyCard(MakeDataCard):
             total_remove = 0
             for rule in rules:
                 element = rule.get("element")
-                count = int(rule.get("count", 0))
-                if not element or count <= 0:
+                count_min, count_max = rule.get("count", [0, 0])
+                if not element or int(count_max) <= 0:
                     continue
 
                 groups = rule.get("group")
@@ -1030,7 +1033,8 @@ class RandomVacancyCard(MakeDataCard):
                 if not candidate_indices:
                     continue
 
-                remove_num = min(count, len(candidate_indices))
+                remove_num = np.random.randint(int(count_min), int(count_max) + 1)
+                remove_num = min(remove_num, len(candidate_indices))
                 if remove_num <= 0:
                     continue
 


### PR DESCRIPTION
## Summary
- allow doping and vacancy rules to specify ranges
- handle uniform sampling within those ranges when generating defects

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'NepTrainKit' etc.)*