### PR TITLE
Add energy baseline shift tool

### DIFF
--- a/src/NepTrainKit/core/energy_shift.py
+++ b/src/NepTrainKit/core/energy_shift.py
@@ -1,0 +1,113 @@
+"""Utilities for shifting structure energies using atomic baselines."""
+
+from __future__ import annotations
+
+import numpy as np
+from collections import Counter
+from typing import List, Dict
+
+from .structure import Structure
+
+
+def atomic_baseline_cost(param_population: np.ndarray,
+                         energies: np.ndarray,
+                         element_counts: np.ndarray,
+                         target_energies: np.ndarray) -> np.ndarray:
+    """Vectorized MSE cost for atomic reference baseline."""
+    shifted = energies[None, :] - np.dot(param_population, element_counts.T)
+    cost = np.mean((shifted - target_energies[None, :]) ** 2, axis=1)
+    return cost.reshape(-1, 1)
+
+
+def nes_optimize_atomic_baseline(num_variables: int,
+                                 max_generations: int,
+                                 energies: np.ndarray,
+                                 element_counts: np.ndarray,
+                                 targets: np.ndarray,
+                                 pop_size: int = 40,
+                                 tol: float = 1e-8,
+                                 seed: int = 42,
+                                 print_every: int = 100) -> np.ndarray:
+    """NES optimizer for atomic reference energies."""
+    np.random.seed(seed)
+
+    best_fitness = np.ones((max_generations, 1))
+    elite = np.zeros((max_generations, num_variables))
+    mean = -1 * np.random.rand(1, num_variables)
+    stddev = 0.1 * np.ones((1, num_variables))
+    lr_mean = 1.0
+    lr_std = (3 + np.log(num_variables)) / (5 * np.sqrt(num_variables)) / 2
+    weights = np.maximum(0, np.log(pop_size / 2 + 1) - np.log(np.arange(1, pop_size + 1)))
+    weights = weights / np.sum(weights) - 1 / pop_size
+
+    for gen in range(max_generations):
+        z = np.random.randn(pop_size, num_variables)
+        pop = mean + stddev * z
+        fitness = atomic_baseline_cost(pop, energies, element_counts, targets)
+        idx = np.argsort(fitness.flatten())
+        fitness = fitness[idx]
+        z = z[idx, :]
+        pop = pop[idx, :]
+        best_fitness[gen] = fitness[0]
+        elite[gen, :] = pop[0, :]
+        mean += lr_mean * stddev * (weights @ z)
+        stddev *= np.exp(lr_std * (weights @ (z ** 2 - 1)))
+        if gen > 0 and abs(best_fitness[gen] - best_fitness[gen - 1]) < tol:
+            best_fitness = best_fitness[:gen + 1]
+            elite = elite[:gen + 1]
+            break
+    return elite[-1]
+
+
+def shift_dataset_energy(structures: List[Structure],
+                         reference_index: int,
+                         max_generations: int = 100000,
+                         population_size: int = 40,
+                         convergence_tol: float = 1e-8,
+                         random_seed: int = 42) -> Dict[str, np.ndarray]:
+    """Shift structure energies so that groups align to the reference structure."""
+    frames = []
+    for s in structures:
+        energy = float(s.additional_fields.get("energy", 0.0))
+        config_type = str(s.additional_fields.get("Config_type", ""))
+        elem_counts = Counter(s.elements)
+        frames.append({"energy": energy, "config_type": config_type, "elem_counts": elem_counts})
+
+    all_elements = sorted({e for f in frames for e in f["elem_counts"]})
+    num_elements = len(all_elements)
+
+    reference_group = frames[reference_index]["config_type"]
+    ref_energies = np.array([f["energy"] for f in frames if f["config_type"] == reference_group])
+    ref_mean = np.mean(ref_energies)
+
+    all_config_types = {f["config_type"] for f in frames}
+    shift_groups = [g for g in all_config_types if g != reference_group]
+
+    group_to_atomic_ref = {}
+    for group in shift_groups:
+        grp_frames = [f for f in frames if f["config_type"] == group]
+        if not grp_frames:
+            continue
+        energies = np.array([f["energy"] for f in grp_frames])
+        counts = np.array([[f["elem_counts"].get(e, 0) for e in all_elements] for f in grp_frames], dtype=float)
+        targets = np.full_like(energies, ref_mean)
+        atomic_ref = nes_optimize_atomic_baseline(num_elements,
+                                                  max_generations,
+                                                  energies,
+                                                  counts,
+                                                  targets,
+                                                  pop_size=population_size,
+                                                  tol=convergence_tol,
+                                                  seed=random_seed,
+                                                  print_every=100)
+        group_to_atomic_ref[group] = atomic_ref
+
+    # apply shift
+    for s, frame in zip(structures, frames):
+        group = frame["config_type"]
+        if group in group_to_atomic_ref:
+            count_vec = np.array([frame["elem_counts"].get(e, 0) for e in all_elements], dtype=float)
+            shift = np.dot(count_vec, group_to_atomic_ref[group])
+            new_energy = frame["energy"] - shift
+            s.additional_fields["energy"] = new_energy
+    return group_to_atomic_ref

--- a/src/NepTrainKit/core/views/toolbar.py
+++ b/src/NepTrainKit/core/views/toolbar.py
@@ -42,6 +42,7 @@ class NepDisplayGraphicsToolBar(KitToolBarBase):
     deleteSignal=Signal()
     revokeSignal=Signal()
     exportSignal=Signal()
+    shiftEnergySignal=Signal()
 
     def init_actions(self):
         self.addButton("Reset View",QIcon(":/images/src/images/init.svg"),self.resetSignal)
@@ -82,6 +83,10 @@ class NepDisplayGraphicsToolBar(KitToolBarBase):
         export_action = self.addButton("Export structure descriptor",
                                      QIcon(":/images/src/images/export.svg"),
                                      self.exportSignal)
+        self.addSeparator()
+        self.addButton("Energy Baseline Shift",
+                       QIcon(":/images/src/images/scaling.svg"),
+                       self.shiftEnergySignal)
 
     def reset(self):
         if self.action_group.checkedAction():


### PR DESCRIPTION
## Summary
- add utilities to shift energies across config types using NES optimizer
- expose shift action in toolbar and wire it into the viewer

## Testing
- `pytest -q` *(fails: libEGL missing)*