### PR TITLE
Add inverse selection

### DIFF
--- a/src/NepTrainKit/core/canvas/base/canvas.py
+++ b/src/NepTrainKit/core/canvas/base/canvas.py
@@ -156,6 +156,14 @@ class CanvasLayoutBase(CanvasBase):
             self.nep_result_data.select(structure_index)
 
             self.update_scatter_color(structure_index, Brushes.Selected)
+
+    def inverse_select(self):
+        if self.nep_result_data is None:
+            return
+        active_indices = set(self.nep_result_data.structure.now_indices.tolist())
+        selected = set(self.nep_result_data.select_index)
+        self.select_index(list(selected), True)
+        self.select_index(list(active_indices - selected), False)
 class VispyCanvasLayoutBase(CanvasLayoutBase,QObject,metaclass=CombinedMeta):
     def __init__(self,*args,**kwargs):
         QObject.__init__(self)

--- a/src/NepTrainKit/core/io/nep.py
+++ b/src/NepTrainKit/core/io/nep.py
@@ -155,6 +155,17 @@ class ResultData(QObject):
                 self.select_index.remove(i)
 
         self.updateInfoSignal.emit()
+
+    def inverse_select(self):
+        """Invert the current selection state of all active structures"""
+        active_indices = set(self.structure.data.now_indices.tolist())
+        selected_indices = set(self.select_index)
+        unselect = list(selected_indices)
+        select = list(active_indices - selected_indices)
+        if unselect:
+            self.uncheck(unselect)
+        if select:
+            self.select(select)
     def export_selected_xyz(self,save_file_path):
         """
         导出当前选中的结构

--- a/src/NepTrainKit/core/views/nep.py
+++ b/src/NepTrainKit/core/views/nep.py
@@ -69,6 +69,7 @@ class NepResultPlotWidget(QWidget):
         self.tool_bar.discoverySignal.connect(self.find_non_physical_structures)
         self.tool_bar.sparseSignal.connect(self.sparse_point)
         self.tool_bar.shiftEnergySignal.connect(self.shift_energy_baseline)
+        self.tool_bar.inverseSignal.connect(self.inverse_select)
         self.canvas.tool_bar=self.tool_bar
 
 
@@ -213,6 +214,9 @@ class NepResultPlotWidget(QWidget):
                 # print(s.per_atom_energy)
                 data.energy.data._data[i, 1] = s.per_atom_energy
         self.canvas.plot_nep_result()
+
+    def inverse_select(self):
+        self.canvas.inverse_select()
 
     def set_dataset(self,dataset):
 

--- a/src/NepTrainKit/core/views/toolbar.py
+++ b/src/NepTrainKit/core/views/toolbar.py
@@ -43,6 +43,7 @@ class NepDisplayGraphicsToolBar(KitToolBarBase):
     revokeSignal=Signal()
     exportSignal=Signal()
     shiftEnergySignal=Signal()
+    inverseSignal=Signal()
 
     def init_actions(self):
         self.addButton("Reset View",QIcon(":/images/src/images/init.svg"),self.resetSignal)
@@ -79,6 +80,9 @@ class NepDisplayGraphicsToolBar(KitToolBarBase):
         delete_action = self.addButton("Delete Selected Items",
                                      QIcon(":/images/src/images/delete.svg"),
                                      self.deleteSignal)
+        inverse_action = self.addButton("Inverse Selection",
+                                     QIcon(":/images/src/images/show.svg"),
+                                     self.inverseSignal)
         self.addSeparator()
         export_action = self.addButton("Export structure descriptor",
                                      QIcon(":/images/src/images/export.svg"),

--- a/tests/test_nep.py
+++ b/tests/test_nep.py
@@ -66,6 +66,16 @@ class TestNepTrainResultData( unittest.TestCase):
         os.remove(os.path.join(self.data_dir,"virial_train.out"))
         os.remove(os.path.join(self.data_dir,"descriptor.out"))
 
+    def test_inverse_select(self):
+        result = NepTrainResultData.from_path(self.train_path)
+        result.load()
+        result.select([0,1,3])
+        result.uncheck(0)
+        result.inverse_select()
+        self.assertEqual(len(result.select_index), result.num-2)
+        self.assertNotIn(1, result.select_index)
+        self.assertNotIn(3, result.select_index)
+
 
 class TestNepPolarizabilityResultData( unittest.TestCase):
     def setUp(self):
@@ -110,6 +120,16 @@ class TestNepPolarizabilityResultData( unittest.TestCase):
         os.remove(os.path.join(self.data_dir,"polarizability_train.out"))
         os.remove(os.path.join(self.data_dir,"descriptor.out"))
 
+    def test_inverse_select(self):
+        result = NepPolarizabilityResultData.from_path(self.train_path)
+        result.load()
+        result.select([0,1,3])
+        result.uncheck(0)
+        result.inverse_select()
+        self.assertEqual(len(result.select_index), result.num-2)
+        self.assertNotIn(1, result.select_index)
+        self.assertNotIn(3, result.select_index)
+
 class TestNepDipoleResultData(unittest.TestCase):
     def setUp(self):
 
@@ -151,6 +171,16 @@ class TestNepDipoleResultData(unittest.TestCase):
         result.load()
         os.remove(os.path.join(self.data_dir,"dipole_train.out"))
         os.remove(os.path.join(self.data_dir,"descriptor.out"))
+
+    def test_inverse_select(self):
+        result = NepDipoleResultData.from_path(self.train_path)
+        result.load()
+        result.select([0,1,3])
+        result.uncheck(0)
+        result.inverse_select()
+        self.assertEqual(len(result.select_index), result.num-2)
+        self.assertNotIn(1, result.select_index)
+        self.assertNotIn(3, result.select_index)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support inverting selections from the toolbar
- expose inverse selection on result data and canvas
- connect inverse selection signal to the graph widget
- test inverse selection

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_683c3db71ad0832eba0e98d0e83f12a8