### PR TITLE
Add index-based selection

### DIFF
--- a/src/NepTrainKit/core/custom_widget/__init__.py
+++ b/src/NepTrainKit/core/custom_widget/__init__.py
@@ -9,6 +9,7 @@ from .completer import CompleterModel, JoinDelegate, ConfigCompleter
 from .dialog import (
     GetIntMessageBox,
     SparseMessageBox,
+    IndexSelectMessageBox,
     ProgressDialog,
     PeriodicTableDialog,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "ConfigCompleter",
     "GetIntMessageBox",
     "SparseMessageBox",
+    "IndexSelectMessageBox",
     "ProgressDialog",
     "PeriodicTableDialog",
     "SpinBoxUnitInputFrame",

--- a/src/NepTrainKit/core/custom_widget/dialog.py
+++ b/src/NepTrainKit/core/custom_widget/dialog.py
@@ -4,13 +4,14 @@
 # @Author  : 兵
 # @email    : 1747193328@qq.com
 from PySide6.QtGui import QIcon
-from PySide6.QtWidgets import QVBoxLayout, QFrame, QGridLayout, QPushButton
+from PySide6.QtWidgets import QVBoxLayout, QFrame, QGridLayout, QPushButton, QLineEdit
 from PySide6.QtCore import Signal, Qt
 from qfluentwidgets import (
     MessageBoxBase,
     SpinBox,
     CaptionLabel,
     DoubleSpinBox,
+    CheckBox,
     ProgressBar,
     FluentStyleSheet,
     FluentTitleBar,
@@ -71,6 +72,26 @@ class SparseMessageBox(MessageBoxBase):
         self.yesButton.setText('Ok')
         self.cancelButton.setText('Cancel')
 
+        self.widget.setMinimumWidth(200)
+
+
+class IndexSelectMessageBox(MessageBoxBase):
+    """Dialog for selecting structures by index."""
+
+    def __init__(self, parent=None, tip="Specify index or slice"):
+        super().__init__(parent)
+        self.titleLabel = CaptionLabel(tip, self)
+        self.titleLabel.setWordWrap(True)
+        self.indexEdit = QLineEdit(self)
+        self.checkBox = CheckBox("Use original indices", self)
+        self.checkBox.setChecked(True)
+
+        self.viewLayout.addWidget(self.titleLabel)
+        self.viewLayout.addWidget(self.indexEdit)
+        self.viewLayout.addWidget(self.checkBox)
+
+        self.yesButton.setText('Ok')
+        self.cancelButton.setText('Cancel')
         self.widget.setMinimumWidth(200)
 
 class ProgressDialog(FramelessDialog):

--- a/src/NepTrainKit/core/views/nep.py
+++ b/src/NepTrainKit/core/views/nep.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import QHBoxLayout, QWidget, QProgressDialog
 
 from NepTrainKit import utils
 from NepTrainKit.core import MessageManager, Config
-from NepTrainKit.core.custom_widget import GetIntMessageBox, SparseMessageBox
+from NepTrainKit.core.custom_widget import GetIntMessageBox, SparseMessageBox, IndexSelectMessageBox
 from NepTrainKit.core.io.select import farthest_point_sampling
 from NepTrainKit.core.views.toolbar import NepDisplayGraphicsToolBar
 from NepTrainKit.core.energy_shift import shift_dataset_energy
@@ -70,6 +70,7 @@ class NepResultPlotWidget(QWidget):
         self.tool_bar.sparseSignal.connect(self.sparse_point)
         self.tool_bar.shiftEnergySignal.connect(self.shift_energy_baseline)
         self.tool_bar.inverseSignal.connect(self.inverse_select)
+        self.tool_bar.selectIndexSignal.connect(self.select_by_index)
         self.canvas.tool_bar=self.tool_bar
 
 
@@ -217,6 +218,23 @@ class NepResultPlotWidget(QWidget):
 
     def inverse_select(self):
         self.canvas.inverse_select()
+
+    def select_by_index(self):
+        if self.canvas.nep_result_data is None:
+            return
+        box = IndexSelectMessageBox(self._parent, "Select structures by index")
+        if not box.exec():
+            return
+        text = box.indexEdit.text().strip()
+        use_origin = box.checkBox.isChecked()
+        data = self.canvas.nep_result_data.structure
+        total = data.all_data.shape[0] if use_origin else data.now_data.shape[0]
+        indices = utils.parse_index_string(text, total)
+        if not indices:
+            return
+        if not use_origin:
+            indices = data.group_array.now_data[indices].tolist()
+        self.canvas.select_index(indices, False)
 
     def set_dataset(self,dataset):
 

--- a/src/NepTrainKit/core/views/toolbar.py
+++ b/src/NepTrainKit/core/views/toolbar.py
@@ -44,6 +44,7 @@ class NepDisplayGraphicsToolBar(KitToolBarBase):
     exportSignal=Signal()
     shiftEnergySignal=Signal()
     inverseSignal=Signal()
+    selectIndexSignal=Signal()
 
     def init_actions(self):
         self.addButton("Reset View",QIcon(":/images/src/images/init.svg"),self.resetSignal)
@@ -58,6 +59,10 @@ class NepDisplayGraphicsToolBar(KitToolBarBase):
         sparse_action=self.addButton("Sparse samples",
                                     QIcon(":/images/src/images/sparse.svg"),
                                     self.sparseSignal)
+
+        self.addButton("Select by Index",
+                       QIcon(":/images/src/images/search.svg"),
+                       self.selectIndexSignal)
 
 
         pen_action=self.addButton("Mouse Selection",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,6 @@
+import NepTrainKit.utils as utils
+
+def test_parse_index_string():
+    assert utils.parse_index_string('1:4', 10) == [1,2,3]
+    assert utils.parse_index_string(':3', 5) == [0,1,2]
+    assert utils.parse_index_string('::2', 5) == [0,2,4]


### PR DESCRIPTION
## Summary
- add `parse_index_string` helper in utils
- add `IndexSelectMessageBox` dialog
- expose new widget from custom_widget package
- update Nep toolbar to trigger index selection
- handle index selection in NEP view
- test parsing helper

## Testing
- `pytest tests/test_utils.py::test_parse_index_string -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_683da943408c832ea591238bf7ec3915