### PR TITLE
Add energy alignment modes

### DIFF
--- a/src/NepTrainKit/core/custom_widget/dialog.py
+++ b/src/NepTrainKit/core/custom_widget/dialog.py
@@ -13,6 +13,7 @@ from qfluentwidgets import (
     DoubleSpinBox,
     CheckBox,
     ProgressBar,
+    ComboBox,
     FluentStyleSheet,
     FluentTitleBar,
     TitleLabel
@@ -116,6 +117,13 @@ class ShiftEnergyMessageBox(MessageBoxBase):
         self.tolSpinBox = DoubleSpinBox(self)
         self.tolSpinBox.setDecimals(8)
         self.tolSpinBox.setMinimum(0)
+        self.modeCombo = ComboBox(self)
+        self.modeCombo.addItems([
+            "REF_GROUP_ALIGNMENT",
+            "ZERO_BASELINE_ALIGNMENT",
+            "DFT_TO_NEP_ALIGNMENT",
+        ])
+        self.nepLineEdit = QLineEdit(self)
 
         self.frame_layout.addWidget(CaptionLabel("Max generations", self), 0, 0)
         self.frame_layout.addWidget(self.genSpinBox, 0, 1)
@@ -123,6 +131,10 @@ class ShiftEnergyMessageBox(MessageBoxBase):
         self.frame_layout.addWidget(self.sizeSpinBox, 1, 1)
         self.frame_layout.addWidget(CaptionLabel("Convergence tol", self), 2, 0)
         self.frame_layout.addWidget(self.tolSpinBox, 2, 1)
+        self.frame_layout.addWidget(CaptionLabel("Mode", self), 3, 0)
+        self.frame_layout.addWidget(self.modeCombo, 3, 1)
+        self.frame_layout.addWidget(CaptionLabel("NEP model", self), 4, 0)
+        self.frame_layout.addWidget(self.nepLineEdit, 4, 1)
 
         self.viewLayout.addWidget(self.titleLabel)
         self.viewLayout.addWidget(self.groupEdit)

--- a/src/NepTrainKit/core/views/nep.py
+++ b/src/NepTrainKit/core/views/nep.py
@@ -218,6 +218,9 @@ class NepResultPlotWidget(QWidget):
         pattern_text = box.groupEdit.text().strip()
         group_patterns = [p.strip() for p in pattern_text.split(';') if p.strip()]
 
+        alignment_mode = box.modeCombo.currentText()
+        nep_model_file = box.nepLineEdit.text().strip() or None
+
         max_generations = box.genSpinBox.value()
         population_size = box.sizeSpinBox.value()
         convergence_tol = box.tolSpinBox.value()
@@ -240,6 +243,8 @@ class NepResultPlotWidget(QWidget):
             population_size=population_size,
             convergence_tol=convergence_tol,
             group_patterns=group_patterns,
+            alignment_mode=alignment_mode,
+            nep_model_file=nep_model_file,
         )
         progress_diag.exec()
         if hasattr(data, "energy") and data.energy.num != 0:


### PR DESCRIPTION
## Summary
- support three alignment strategies (reference group, zero baseline, DFT to NEP)
- expose alignment options in GUI dialog
- allow GUI to call shift with selected mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68412ce99b6c832eb0f126611ab75f53