### PR TITLE
Add option to sort atoms in cards

### DIFF
--- a/src/NepTrainKit/core/pages/settings.py
+++ b/src/NepTrainKit/core/pages/settings.py
@@ -64,6 +64,8 @@ class SettingsWidget(ScrollArea):
 
         auto_load_config = Config.getboolean("widget","auto_load",False)
 
+        sort_atoms_config = Config.getboolean("widget", "sort_atoms", False)
+
         self.auto_load_card = SwitchSettingCard(
             QIcon(":/images/src/images/auto_load.svg"),
             self.tr('Auto loading'),
@@ -72,6 +74,14 @@ class SettingsWidget(ScrollArea):
             parent=self.personal_group
         )
         self.auto_load_card.setValue(auto_load_config)
+
+        self.sort_atoms_card = SwitchSettingCard(
+            QIcon(":/images/src/images/alignment.svg"),
+            'Sort atoms',
+            'Sort atoms in structures when processing cards',
+            parent=self.personal_group
+        )
+        self.sort_atoms_card.setValue(sort_atoms_config)
         radius_coefficient_config=Config.getfloat("widget","radius_coefficient",0.7)
 
         self.radius_coefficient_Card = DoubleSpinBoxSettingCard(
@@ -131,6 +141,7 @@ class SettingsWidget(ScrollArea):
         self.personal_group.addSettingCard(self.canvas_card)
         self.personal_group.addSettingCard(self.auto_load_card)
         self.personal_group.addSettingCard(self.radius_coefficient_Card)
+        self.personal_group.addSettingCard(self.sort_atoms_card)
 
         self.about_group.addSettingCard(self.about_nep89_card)
         self.about_group.addSettingCard(self.help_card)
@@ -149,6 +160,7 @@ class SettingsWidget(ScrollArea):
         self.about_nep89_card.clicked.connect(self.check_update_nep89)
 
         self.auto_load_card.checkedChanged.connect(lambda state:Config.set("widget","auto_load",state))
+        self.sort_atoms_card.checkedChanged.connect(lambda state:Config.set("widget","sort_atoms",state))
         # self.about_card.clicked.connect(lambda: QDesktopServices.openUrl(QUrl(RELEASES_URL)))
         self.feedback_card.clicked.connect(
             lambda: QDesktopServices.openUrl(QUrl(FEEDBACK_URL)))

--- a/src/NepTrainKit/utils.py
+++ b/src/NepTrainKit/utils.py
@@ -17,6 +17,7 @@ from loguru import logger
 from qfluentwidgets import StateToolTip
 
 from NepTrainKit.core import Config
+from ase.build.tools import sort as ase_sort
 from NepTrainKit.version import UPDATE_EXE, UPDATE_FILE, NepTrainKit_EXE
 
 
@@ -167,9 +168,12 @@ class DataProcessingThread(QThread):
         try:
             total = len(self.dataset)
             self.progressSignal.emit(0)
+            sort_atoms = Config.getboolean("widget", "sort_atoms", False)
             for index, structure in enumerate(self.dataset):
                 # 处理每个结构
                 processed = self.process_func(structure)
+                if sort_atoms:
+                    processed = [ase_sort(s) for s in processed]
 
                 self.result_dataset.extend(processed)
 


### PR DESCRIPTION
## Summary
- allow `DataProcessingThread` to optionally sort atoms using ASE
- add settings toggle for sorting atoms

## Testing
- `pytest -q` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d5367c548832ea29f0b605dbcb48c