### PR TITLE
Add tag attribute for Structure

### DIFF
--- a/src/NepTrainKit/core/energy_shift.py
+++ b/src/NepTrainKit/core/energy_shift.py
@@ -134,7 +134,7 @@ def shift_dataset_energy(
     frames = []
     for s in structures:
         energy = float(s.energy)
-        config_type = str(s.additional_fields.get("Config_type", ""))
+        config_type = str(s.tag)
         elem_counts = Counter(s.elements)
 
         frames.append({"energy": energy, "config_type": config_type, "elem_counts": elem_counts})

--- a/src/NepTrainKit/core/io/base.py
+++ b/src/NepTrainKit/core/io/base.py
@@ -220,9 +220,9 @@ class StructureData(NepData):
     @utils.timeit
     def get_all_config(self):
 
-        return [structure.additional_fields["Config_type"]  for structure in self.now_data]
+        return [structure.tag for structure in self.now_data]
 
     def search_config(self,config):
 
-        result_index=[i for i ,structure in enumerate(self.now_data) if re.search(config, structure.additional_fields["Config_type"])]
+        result_index=[i for i ,structure in enumerate(self.now_data) if re.search(config, structure.tag)]
         return self.group_array[result_index].tolist()

--- a/src/NepTrainKit/core/structure.py
+++ b/src/NepTrainKit/core/structure.py
@@ -62,6 +62,15 @@ class Structure:
         else:
             self.force_label = "force"
 
+    @property
+    def tag(self):
+        """Alias for the ``Config_type`` additional field."""
+        return self.additional_fields.get("Config_type", "")
+
+    @tag.setter
+    def tag(self, value):
+        self.additional_fields["Config_type"] = value
+
     def __len__(self):
         return len(self.elements)
 

--- a/src/NepTrainKit/views/structure.py
+++ b/src/NepTrainKit/views/structure.py
@@ -62,5 +62,5 @@ class StructureInfoWidget(QWidget):
         self.atom_num_text.setText(str(len(structure )))
         self.formula_text.setText(structure.html_formula)
         self.lattice_text.setText(str(np.round(structure.lattice,3)))
-        self.config_text.setText(structure.Config_type)
+        self.config_text.setText(structure.tag)
 


### PR DESCRIPTION
## Summary
- add `tag` property to `Structure` as alias for `Config_type`
- use the new `tag` property in data I/O, energy shift calculations and UI

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685a9c9a39b4832ea891734dfbd0aff1