### PR TITLE
Display lattice lengths and angles

### DIFF
--- a/src/NepTrainKit/core/structure.py
+++ b/src/NepTrainKit/core/structure.py
@@ -88,6 +88,26 @@ class Structure:
         return np.abs(np.linalg.det(self.lattice))
 
     @property
+    def abc(self):
+        """Return lattice vector lengths (a, b, c)."""
+        return np.linalg.norm(self.lattice, axis=1)
+
+    @property
+    def angles(self):
+        """Return lattice angles (alpha, beta, gamma) in degrees."""
+        a_vec, b_vec, c_vec = self.lattice
+
+        def _angle(v1, v2):
+            cos_ang = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
+            cos_ang = np.clip(cos_ang, -1.0, 1.0)
+            return np.degrees(np.arccos(cos_ang))
+
+        alpha = _angle(b_vec, c_vec)
+        beta = _angle(a_vec, c_vec)
+        gamma = _angle(a_vec, b_vec)
+        return np.array([alpha, beta, gamma], dtype=np.float32)
+
+    @property
     def numbers(self):
         return [atomic_numbers[element] for element in self.elements]
 

--- a/src/NepTrainKit/views/structure.py
+++ b/src/NepTrainKit/views/structure.py
@@ -34,10 +34,18 @@ class StructureInfoWidget(QWidget):
         self.formula_text.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         self.formula_text.setWordWrap(True)
 
-        self.lattice_label=BodyLabel(self)
+        self.lattice_label = BodyLabel(self)
         self.lattice_label.setText("Lattice:")
         self.lattice_text = BodyLabel(self)
         self.lattice_text.setWordWrap(True)
+
+        self.length_label = BodyLabel(self)
+        self.length_label.setText("a b c:")
+        self.length_text = BodyLabel(self)
+
+        self.angle_label = BodyLabel(self)
+        self.angle_label.setText("Angles:")
+        self.angle_text = BodyLabel(self)
 
         self.config_label = BodyLabel(self)
         self.config_label.setText("Config Type:")
@@ -56,11 +64,21 @@ class StructureInfoWidget(QWidget):
 
         self._layout.addWidget(self.lattice_label, 3, 0,1,1)
         self._layout.addWidget(self.lattice_text, 3, 1,1,3)
+        self._layout.addWidget(self.length_label, 4, 0,1,1)
+        self._layout.addWidget(self.length_text, 4, 1,1,3)
+        self._layout.addWidget(self.angle_label, 5, 0,1,1)
+        self._layout.addWidget(self.angle_text, 5, 1,1,3)
 
     def show_structure_info(self, structure):
 
         self.atom_num_text.setText(str(len(structure )))
         self.formula_text.setText(structure.html_formula)
         self.lattice_text.setText(str(np.round(structure.lattice,3)))
+        self.length_text.setText(
+            " ".join(f"{x:.3f}" for x in structure.abc)
+        )
+        self.angle_text.setText(
+            " ".join(f"{x:.2f}°" for x in structure.angles)
+        )
         self.config_text.setText(structure.tag)
 


### PR DESCRIPTION
## Summary
- compute lattice lengths `abc` and angles in `Structure`
- show lengths and angles in `StructureInfoWidget`

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685e767e4a4c832e8dc1daeea1d20fc7