### PR TITLE
Add group menu option

### DIFF
--- a/src/NepTrainKit/custom_widget/card_widget.py
+++ b/src/NepTrainKit/custom_widget/card_widget.py
@@ -61,6 +61,11 @@ class ShareCheckableHeaderCardWidget(CheckableHeaderCardWidget):
         self.headerLayout.addWidget(self.close_button, 0, Qt.AlignmentFlag.AlignRight)
 
 class MakeDataCardWidget(ShareCheckableHeaderCardWidget):
+    """Base class for cards used in console workflow."""
+
+    # group name used for card menu categorization
+    group = None
+
     windowStateChangedSignal=Signal( )
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/src/NepTrainKit/pages/settings.py
+++ b/src/NepTrainKit/pages/settings.py
@@ -66,6 +66,8 @@ class SettingsWidget(ScrollArea):
 
         sort_atoms_config = Config.getboolean("widget", "sort_atoms", False)
 
+        use_group_menu_config = Config.getboolean("widget", "use_group_menu", False)
+
         self.auto_load_card = SwitchSettingCard(
             QIcon(":/images/src/images/auto_load.svg"),
             self.tr('Auto loading'),
@@ -82,6 +84,14 @@ class SettingsWidget(ScrollArea):
             parent=self.personal_group
         )
         self.sort_atoms_card.setValue(sort_atoms_config)
+
+        self.use_group_menu_card = SwitchSettingCard(
+            QIcon(":/images/src/images/group.svg"),
+            'Use card group menu',
+            'Group cards by "group" in console menu',
+            parent=self.personal_group
+        )
+        self.use_group_menu_card.setValue(use_group_menu_config)
         radius_coefficient_config=Config.getfloat("widget","radius_coefficient",0.7)
 
         self.radius_coefficient_Card = DoubleSpinBoxSettingCard(
@@ -142,6 +152,7 @@ class SettingsWidget(ScrollArea):
         self.personal_group.addSettingCard(self.auto_load_card)
         self.personal_group.addSettingCard(self.radius_coefficient_Card)
         self.personal_group.addSettingCard(self.sort_atoms_card)
+        self.personal_group.addSettingCard(self.use_group_menu_card)
 
         self.about_group.addSettingCard(self.about_nep89_card)
         self.about_group.addSettingCard(self.help_card)
@@ -161,6 +172,7 @@ class SettingsWidget(ScrollArea):
 
         self.auto_load_card.checkedChanged.connect(lambda state:Config.set("widget","auto_load",state))
         self.sort_atoms_card.checkedChanged.connect(lambda state:Config.set("widget","sort_atoms",state))
+        self.use_group_menu_card.checkedChanged.connect(lambda state:Config.set("widget","use_group_menu",state))
         # self.about_card.clicked.connect(lambda: QDesktopServices.openUrl(QUrl(RELEASES_URL)))
         self.feedback_card.clicked.connect(
             lambda: QDesktopServices.openUrl(QUrl(FEEDBACK_URL)))

--- a/src/NepTrainKit/views/cards.py
+++ b/src/NepTrainKit/views/cards.py
@@ -11,7 +11,7 @@ from PySide6.QtWidgets import QGridLayout, QWidget
 from qfluentwidgets import RoundMenu, PrimaryDropDownPushButton, CommandBar, Action, ToolTipFilter, ToolTipPosition
 
 from NepTrainKit import get_user_config_path
-from NepTrainKit.core import load_cards_from_directory, CardManager
+from NepTrainKit.core import load_cards_from_directory, CardManager, Config
 from ase.io import extxyz,cif,vasp
 from NepTrainKit.views._card import *
 
@@ -44,13 +44,31 @@ class ConsoleWidget(QWidget):
         self.new_card_button.installEventFilter(ToolTipFilter(self.new_card_button, 300, ToolTipPosition.TOP))
 
         self.menu = RoundMenu(parent=self)
-        for class_name,card_class in CardManager.card_info_dict.items():
 
-            if card_class.separator:
-                self.menu.addSeparator()
-            action = QAction(QIcon(card_class.menu_icon),card_class.card_name)
-            action.setObjectName(class_name)
-            self.menu.addAction(action)
+        use_group_menu = Config.getboolean("widget", "use_group_menu", False)
+        if use_group_menu:
+            group_menus = {}
+            for class_name, card_class in CardManager.card_info_dict.items():
+                group = getattr(card_class, "group", None)
+                target_menu = self.menu
+                if group:
+                    if group not in group_menus:
+                        group_menu = RoundMenu(group, self.menu)
+                        group_menus[group] = group_menu
+                        self.menu.addMenu(group_menu)
+                    target_menu = group_menus[group]
+                if card_class.separator:
+                    target_menu.addSeparator()
+                action = QAction(QIcon(card_class.menu_icon), card_class.card_name)
+                action.setObjectName(class_name)
+                target_menu.addAction(action)
+        else:
+            for class_name, card_class in CardManager.card_info_dict.items():
+                if card_class.separator:
+                    self.menu.addSeparator()
+                action = QAction(QIcon(card_class.menu_icon), card_class.card_name)
+                action.setObjectName(class_name)
+                self.menu.addAction(action)
 
 
         self.menu.triggered.connect(self.menu_clicked)


### PR DESCRIPTION
## Summary
- add `group` attribute to `MakeDataCardWidget`
- enable grouping cards in the console menu via new setting
- expose switch card in `SettingsWidget`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68650e6124148326a031a188f108d093