### PR TITLE
Add Gaussian option for random engines

### DIFF
--- a/docs/source/module/make-dataset.md
+++ b/docs/source/module/make-dataset.md
@@ -101,7 +101,7 @@ structure.info["Config_type"] += "supercell(nx,ny,nz)"  # e.g., supercell(2,2,1)
 **Function**: Creates vacancy-defect structures by deleting random atoms
 
 **Key Parameters**:
-- **Random engine**: `Sobol` sequence or `Uniform` distribution
+- **Random engine**: `Sobol`, `Uniform` or `Gaussian` distribution
 - **Vacancy specification**:
   - *Vacancy num*: fixed number of vacancies
   - *Vacancy concentration*: fraction of atoms to remove
@@ -116,7 +116,7 @@ structure.info["Config_type"] += f" Vacancy(num={defect_count})"
 **Function**: Adds random displacements to atomic positions
 
 **Key Parameters**:
-- **Random engine**: `Sobol` or `Uniform`
+- **Random engine**: `Sobol`, `Uniform` or `Gaussian`
 - **Max distance**: maximum displacement amplitude in Å
 - **Identify organic**: treat organic molecules as rigid units
 - **Max structures**: number of structures to generate
@@ -130,7 +130,7 @@ structure.info["Config_type"] += f" Perturb(distance={max_displacement}, {engine
 **Function**: Randomly scales lattice vectors
 
 **Key Parameters**:
-- **Random engine**: `Sobol` or `Uniform`
+- **Random engine**: `Sobol`, `Uniform` or `Gaussian`
 - **Max scaling**: 0–1, applied symmetrically as `1±value`
 - **Perturb angle**: whether lattice angles are also perturbed
 - **Identify organic**: treat organic molecules as rigid units

--- a/src/NepTrainKit/views/_card/cell_scaling_card.py
+++ b/src/NepTrainKit/views/_card/cell_scaling_card.py
@@ -32,6 +32,7 @@ class CellScalingCard(MakeDataCard):
         self.engine_type_combo=ComboBox(self.setting_widget)
         self.engine_type_combo.addItem("Sobol")
         self.engine_type_combo.addItem("Uniform")
+        self.engine_type_combo.addItem("Gaussian")
         self.engine_type_combo.setCurrentIndex(1)
         self.engine_label.setToolTip("Select random engine")
         self.engine_label.installEventFilter(ToolTipFilter(self.engine_label, 300, ToolTipPosition.TOP))
@@ -106,8 +107,10 @@ class CellScalingCard(MakeDataCard):
             sobol_engine = Sobol(d=dim, scramble=True)
             sobol_seq = sobol_engine.random(max_num)  # 生成 [0, 1] 的序列
             perturbation_factors = 1 + (sobol_seq - 0.5) * 2 * max_scaling
-        else:
+        elif engine_type == 1:
             perturbation_factors = 1 + np.random.uniform(-max_scaling, max_scaling, (max_num, dim))
+        else:
+            perturbation_factors = 1 + np.random.normal(0, max_scaling / 2, (max_num, dim))
 
         orig_lattice = structure.cell.array
         orig_lengths = np.linalg.norm(orig_lattice, axis=1)
@@ -145,7 +148,13 @@ class CellScalingCard(MakeDataCard):
 
             # 缩放原子位置
 
-            new_structure.info["Config_type"] = new_structure.info.get("Config_type","") + f" Scaling(scaling={max_scaling},{'uniform' if engine_type==1 else 'Sobol'  })"
+            if engine_type == 0:
+                engine = 'Sobol'
+            elif engine_type == 1:
+                engine = 'uniform'
+            else:
+                engine = 'gaussian'
+            new_structure.info["Config_type"] = new_structure.info.get("Config_type","") + f" Scaling(scaling={max_scaling},{engine})"
 
             new_structure.set_cell(new_lattice,  scale_atoms=True)
             if identify_organic:

--- a/src/NepTrainKit/views/_card/perturb_card.py
+++ b/src/NepTrainKit/views/_card/perturb_card.py
@@ -31,6 +31,7 @@ class PerturbCard(MakeDataCard):
         self.engine_type_combo=ComboBox(self.setting_widget)
         self.engine_type_combo.addItem("Sobol")
         self.engine_type_combo.addItem("Uniform")
+        self.engine_type_combo.addItem("Gaussian")
         self.engine_type_combo.setCurrentIndex(1)
 
         self.engine_label.setToolTip("Select random engine")
@@ -99,8 +100,10 @@ class PerturbCard(MakeDataCard):
         if engine_type == 0:
             sobol_engine = Sobol(d=dim, scramble=True)
             perturbation_factors = (sobol_engine.random(max_num) - 0.5) * 2
-        else:
+        elif engine_type == 1:
             perturbation_factors = np.random.uniform(-1, 1, (max_num, dim))
+        else:
+            perturbation_factors = np.random.normal(0, 1, (max_num, dim))
 
         # 识别团簇（如启用）
         if identify_organic:
@@ -133,7 +136,13 @@ class PerturbCard(MakeDataCard):
             new_structure = structure.copy()
             new_structure.set_positions(new_positions)
             new_structure.wrap()
-            config_str = f" Perturb(distance={max_scaling}, {'uniform' if engine_type == 1 else 'Sobol'})"
+            if engine_type == 0:
+                engine = 'Sobol'
+            elif engine_type == 1:
+                engine = 'uniform'
+            else:
+                engine = 'gaussian'
+            config_str = f" Perturb(distance={max_scaling}, {engine})"
             new_structure.info["Config_type"] = new_structure.info.get("Config_type", "") + config_str
             structure_list.append(new_structure)
 

--- a/src/NepTrainKit/views/_card/vacancy_defect_card.py
+++ b/src/NepTrainKit/views/_card/vacancy_defect_card.py
@@ -36,6 +36,7 @@ class VacancyDefectCard(MakeDataCard):
         self.engine_type_combo=ComboBox(self.setting_widget)
         self.engine_type_combo.addItem("Sobol")
         self.engine_type_combo.addItem("Uniform")
+        self.engine_type_combo.addItem("Gaussian")
         self.engine_type_combo.setCurrentIndex(1)
 
         self.num_radio_button = RadioButton("Vacancy num",self.setting_widget)
@@ -98,9 +99,17 @@ class VacancyDefectCard(MakeDataCard):
             # 为数量和位置分配维度：1 维用于数量，n_atoms 维用于位置
             sobol_engine = Sobol(d=n_atoms + 1, scramble=True)
             sobol_seq = sobol_engine.random(max_num)  # 生成 [0, 1] 的序列
-        else:
+        elif engine_type == 1:
             # Uniform 模式下分开处理
             defect_counts = np.random.randint(1, max_defects + 1, max_num)
+        else:
+            mean = max_defects / 2
+            std = max(1, max_defects / 6)
+            defect_counts = np.clip(
+                np.random.normal(mean, std, max_num).round().astype(int),
+                1,
+                max_defects,
+            )
 
         for i in range(max_num):
             new_structure =structure.copy()


### PR DESCRIPTION
## Summary
- support Gaussian random engine on perturbation, scaling, and vacancy defect cards
- document new distribution option

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_687064fa42f08326985da2337a6ce181