### PR TITLE
feat: add tag management service and dialog

### DIFF
--- a/src/NepTrainKit/core/dataset/__init__.py
+++ b/src/NepTrainKit/core/dataset/__init__.py
@@ -1,1 +1,2 @@
 from .manager import DatasetManager
+

--- a/src/NepTrainKit/core/dataset/manager.py
+++ b/src/NepTrainKit/core/dataset/manager.py
@@ -5,12 +5,13 @@ from pathlib import Path
 
 from PySide6.QtCore import QObject
 from .database import Database
-from .services import ModelService,ProjectService
+from .services import ModelService,ProjectService,TagService
 
 class DatasetManager:
     _db:Database
     _model_service:ModelService
     _project_service:ProjectService
+    _tag_service:TagService
     def __init__(self,*args,**kwargs):
         # super().__init__(parent)
 
@@ -36,6 +37,14 @@ class DatasetManager:
     @project_service.setter
     def project_service(self, service):
         self._project_service = service
+
+    @property
+    def tag_service(self):
+        return self._tag_service
+
+    @tag_service.setter
+    def tag_service(self, service):
+        self._tag_service = service
 
     def gen_test(self):
         try:

--- a/src/NepTrainKit/custom_widget/__init__.py
+++ b/src/NepTrainKit/custom_widget/__init__.py
@@ -15,7 +15,7 @@ from .dialog import (
     EditInfoMessageBox,
     ShiftEnergyMessageBox,
     ProgressDialog,
-    PeriodicTableDialog, DFTD3MessageBox,ProjectInfoMessageBox
+    PeriodicTableDialog, DFTD3MessageBox,ProjectInfoMessageBox, TagManageDialog
 )
 from .input import SpinBoxUnitInputFrame
 from .card_widget import (
@@ -61,6 +61,7 @@ __all__ = [
     "TreeModel",
     "TreeItem",
     "ProjectInfoMessageBox",
-    "TagDelegate"
+    "TagDelegate",
+    "TagManageDialog"
 
 ]

--- a/src/NepTrainKit/pages/data_manager.py
+++ b/src/NepTrainKit/pages/data_manager.py
@@ -11,7 +11,7 @@ from PySide6.QtWidgets import QWidget, QGridLayout, QApplication, QSplitter
 
 from NepTrainKit import get_user_config_path
 from NepTrainKit.core.dataset.database import Database
-from NepTrainKit.core.dataset.services import ModelService, ProjectService
+from NepTrainKit.core.dataset.services import ModelService, ProjectService, TagService
 
 from NepTrainKit.views.dataset_widget import ModelItemWidget
 from NepTrainKit.views.project_view import ProjectWidget
@@ -27,8 +27,8 @@ class DataManagerWidget(QWidget):
         user_path = get_user_config_path()
         self._db = Database(os.path.join(user_path, "mlpman.db"))
         self.model_service = ModelService(self._db)
-
         self.project_service = ProjectService(self._db)
+        self.tag_service = TagService(self._db)
         self.init_ui()
         self.project_widget.gen_nep_data_git()
         # self.project_widget.gen_test()
@@ -62,11 +62,13 @@ class DataManagerWidget(QWidget):
         self.project_widget.db=self._db
         self.project_widget.project_service=self.project_service
         self.project_widget.model_service=self.model_service
+        self.project_widget.tag_service=self.tag_service
         self.splitter.addWidget(self.project_widget)
         self.data_item_widget = ModelItemWidget(self)
         self.data_item_widget.db=self._db
         self.data_item_widget.project_service=self.project_service
         self.data_item_widget.model_service=self.model_service
+        self.data_item_widget.tag_service=self.tag_service
         # self.data_info_widget = QWidget(self)
         # self.data_info_widget.setAutoFillBackground(True)
 

--- a/src/NepTrainKit/views/project_view.py
+++ b/src/NepTrainKit/views/project_view.py
@@ -15,8 +15,7 @@ from NepTrainKit.core.dataset import DatasetManager
 
 from NepTrainKit.core.dataset.database import Database
 from NepTrainKit.core.dataset.services import ModelService, ProjectService, ProjectItem
-from NepTrainKit.custom_widget import IdNameTableModel, TreeModel, TreeItem, ProjectInfoMessageBox
-from NepTrainKit.custom_widget.button import TagGroup
+from NepTrainKit.custom_widget import IdNameTableModel, TreeModel, TreeItem, ProjectInfoMessageBox, TagManageDialog
 from NepTrainKit.views import KitToolBarBase
 
 
@@ -44,25 +43,11 @@ class ProjectWidget(QWidget,DatasetManager):
 
         self._view.setColumnHidden(1,True)
         self._view.setColumnWidth(0,140)
-        # self.tag_widget=QWidget(self)
-        #
-        # self.tag_layout = QVBoxLayout(self.tag_widget )
-        # self.tag_layout.setContentsMargins(0,0,0,0)
-        # self.search_lineedit = SearchLineEdit(self)
-        # self.search_lineedit.setPlaceholderText("please enter a tag name to search for")
-        # self.tag_group= TagGroup([],self)
-        # self.tag_group._layout.setVerticalSpacing(3)
-        # self.tag_group._layout.setHorizontalSpacing(3)
-        #
-        # self.tag_layout.addWidget(self.search_lineedit,1)
-        # self.tag_layout.addWidget(self.tag_group,6)
 
         self._layout = QVBoxLayout(self)
         self._layout.setSpacing(0)
         self._layout.setContentsMargins(0,0,0,0)
-        # self._layout.addWidget(self.tool_bar)
         self._layout.addWidget(self._view)
-        # self._layout.addWidget(self.tag_widget,2)
         self.create_menu()
 
         QTimer.singleShot(1, self.load)
@@ -85,6 +70,9 @@ class ProjectWidget(QWidget,DatasetManager):
         delete_action = Action( "Delete", self.menu)
         delete_action.triggered.connect(self.remove_project)
         self.menu.addAction(delete_action)
+        tag_action = Action("Manage Tags", self.menu)
+        tag_action.triggered.connect(self.manage_tags)
+        self.menu.addAction(tag_action)
 
         self._view.customContextMenuRequested.connect(self.show_menu)
     def show_menu(self,pos):
@@ -170,10 +158,10 @@ class ProjectWidget(QWidget,DatasetManager):
 
     def load(self):
         self.load_all_projects()
-        tags=self.model_service.get_tags()
-        for tag in  tags:
 
-            self.tag_group.add_tag(tag.name,color=tag.color,checkable=True)
+    def manage_tags(self):
+        dlg = TagManageDialog(self.tag_service, self._parent)
+        dlg.exec_()
 
     def _build_tree(self,project,parent:TreeItem):
         child = TreeItem((project.name, project.project_id,project.model_num))


### PR DESCRIPTION
## Summary
- add `TagService` with CRUD operations for tags
- wire tag service into dataset manager and data manager widget
- introduce `TagManageDialog` and context menu in project view to manage tags
- allow renaming tags directly in the management dialog
- enable full tag editing (name, color, notes) via new TagEditDialog

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bacace8fc483269f5fae7cc85ae592