### PR TITLE
fix(ci): 收紧 3.0.1 发布工作流

### DIFF
--- a/.github/workflows/Build-with-Nuitka.yml
+++ b/.github/workflows/Build-with-Nuitka.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag_name }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -78,7 +79,7 @@ jobs:
             --runtime-root "$dist/runtime" `
             --distribution "nep-adapters" `
             --import-name "nep_adapters" `
-            --constraint ">=1.0" `
+            --constraint ">=1.0.1" `
             --health-kind "nep_adapters_cpu" `
             --version "$adapterVersion"
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -95,7 +95,6 @@ jobs:
       PYTHONUTF8: 1
       PYTHONIOENCODING: utf-8
       CIBW_BUILD_VERBOSITY: 1
-      IS_32_BIT: ${{ matrix.buildplat[1] == 'win32' }}
       IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
       IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     strategy:
@@ -114,7 +113,6 @@ jobs:
           - [macos-15-intel, macosx_x86_64, ""]
           - [macos-15, macosx_arm64, ""]  # pin the deployment baseline; macos-latest is macOS 26
           - [windows-2022, win_amd64, ""]
-          - [windows-2022, win32, ""]
 
         python: ["cp310","cp311", "cp312" , "cp313"]
     steps:
@@ -138,12 +136,6 @@ jobs:
         echo "NEPKIT_OPENMP=1" >> "$GITHUB_ENV"
         echo "OMP_INCLUDE_PATH=$(brew --prefix libomp)/include" >> $GITHUB_ENV
         echo "OMP_LIB_PATH=$(brew --prefix libomp)/lib" >> $GITHUB_ENV
-    - name: Setup MSVC (x86)
-      if: ${{ matrix.buildplat[1] == 'win32' }}
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: x86
-
     - name: Setup MSVC (x64)
       if: ${{ matrix.buildplat[1] == 'win_amd64' }}
       uses: ilammy/msvc-dev-cmd@v1

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -93,6 +93,20 @@ def test_windows_standalone_name_matches_verified_x86_64_architecture():
     assert "NepTrainKit.win32.zip" not in workflow
 
 
+def test_release_workflows_target_tagged_x86_64_windows_runtime():
+    publish_workflow = (
+        ROOT / ".github" / "workflows" / "python-publish.yml"
+    ).read_text(encoding="utf-8")
+    nuitka_workflow = (
+        ROOT / ".github" / "workflows" / "Build-with-Nuitka.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "- [windows-2022, win_amd64" in publish_workflow
+    assert "win32" not in publish_workflow
+    assert "ref: ${{ inputs.tag_name }}" in nuitka_workflow
+    assert '--constraint ">=1.0.1"' in nuitka_workflow
+
+
 def test_nuitka_runtime_resources_are_resolved_from_binary_directory():
     package_init = (
         ROOT / "src" / "NepTrainKit" / "__init__.py"


### PR DESCRIPTION
## 变更

- 停止构建和发布 Windows 32 位 wheel，仅保留 win_amd64
- Nuitka workflow 按输入的 release tag 精确 checkout，避免从默认分支构建错误源码
- 将内置 nep-adapters 运行时约束统一为 >=1.0.1
- 增加发布工作流打包契约测试

## 验证

- conda run -n neptrainkit python -m pytest tests/test_packaging_contract.py -q：14 passed
- 两个 workflow 均通过 YAML 解析
- git diff --check 通过

## 边界

本 PR 只修复发布准备工作流，不创建 v3.0.1 tag，不发布 GitHub Release，也不上传 PyPI。