### PR TITLE
fix(ci): 修复 macOS wheel repair 脚本路径

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -164,7 +164,7 @@ jobs:
 
         CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel} &&
-            python {project}/tools/ci/normalize_macos_openmp.py {dest_dir}/*.whl
+            python tools/ci/normalize_macos_openmp.py {dest_dir}/*.whl
 
         CIBW_BEFORE_BUILD_WINDOWS: |
           pip install delvewheel

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -133,6 +133,7 @@ def test_macos_wheels_use_explicit_openmp_repair_and_portability_gate():
     assert "CIBW_REPAIR_WHEEL_COMMAND_MACOS" in workflow
     assert "delocate-wheel --require-archs" in workflow
     assert "normalize_macos_openmp.py {dest_dir}/*.whl" in workflow
+    assert "{project}/tools/ci/normalize_macos_openmp.py" not in workflow
     assert "verify_macos_wheel.py wheelhouse/*.whl" in workflow
 
 


### PR DESCRIPTION
## 根因

cibuildwheel 2.23.2 不展开 repair command 中的 `{project}`。发布构建因此尝试执行字面路径 `.../{project}/tools/ci/normalize_macos_openmp.py`，导致 v3.0.1 wheel 矩阵失败。

## 修复

- 从 cibuildwheel 已位于仓库根目录的工作目录直接执行 `tools/ci/normalize_macos_openmp.py`
- 增加打包契约，禁止重新引入无效的 `{project}` 路径

## 验证

- `conda run -n neptrainkit python -m pytest tests/test_packaging_contract.py -q`：14 passed
- workflow YAML 解析通过
- `git diff --check` 通过

该改动只影响官方 macOS wheel repair，不进入源码安装或运行时编译路径。现有 v3.0.1 Release/tag 保持不变。