### PR TITLE
fix(ci): 修复已有 release 的资产上传

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -197,11 +197,10 @@ jobs:
           merge-multiple: true
 
       - name: Upload artifacts to GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag_name }}
-          files: dist/*
-          overwrite_files: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag_name }}
+        run: gh release upload "$RELEASE_TAG" dist/* --repo "$GITHUB_REPOSITORY" --clobber
 
 #   Upload the wheels and the source distribution
   upload_pypi:

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -137,6 +137,16 @@ def test_macos_wheels_use_explicit_openmp_repair_and_portability_gate():
     assert "verify_macos_wheel.py wheelhouse/*.whl" in workflow
 
 
+def test_release_assets_are_uploaded_without_updating_release_metadata():
+    workflow = (
+        ROOT / ".github" / "workflows" / "python-publish.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "softprops/action-gh-release" not in workflow
+    assert 'gh release upload "$RELEASE_TAG" dist/*' in workflow
+    assert '--repo "$GITHUB_REPOSITORY" --clobber' in workflow
+
+
 def test_test_and_wheel_matrices_cover_documented_python_versions():
     test_workflow = (
         ROOT / ".github" / "workflows" / "pytest.yml"


### PR DESCRIPTION
## 问题

手动重跑发布 workflow 时，softprops/action-gh-release 会更新已有 release 元数据。若 tag 与默认分支之间包含 workflow 文件差异，GitHub 会拒绝 GITHUB_TOKEN 的更新请求，导致 assets 无法上传。

## 修复

- 改用 gh release upload --clobber，仅调用 release asset 上传路径
- 保留 job 级 contents: write
- 增加 packaging contract，防止重新引入 release 元数据更新动作

## 验证

- 15 个 packaging contract 测试通过
- workflow YAML 解析通过
- git diff --check 通过