### PR TITLE
fix(ci): 修复 Nuitka 产物上传

### DIFF
--- a/.github/workflows/Build-with-Nuitka.yml
+++ b/.github/workflows/Build-with-Nuitka.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         os: [windows-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -135,38 +137,8 @@ jobs:
             exit 1
           }
           Write-Host "File exists: $filePath"
-# 获取现有 Release 的 body
-      - name: Get Existing Release Body
-        id: get_release
-        uses: actions/github-script@v6
-        env:
-          TAG_NAME: ${{ inputs.tag_name }}
-        with:
-          script: |
-            try {
-              const { data: release } = await github.rest.repos.getReleaseByTag({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag: process.env.TAG_NAME
-              });
-              core.setOutput('body', release.body || 'No release notes available.');
-              core.setOutput('id', release.id);
-              console.log(`Fetched release body for tag ${process.env.TAG_NAME}`);
-            } catch (error) {
-              core.setOutput('id', null);
-            
-              core.setFailed(`Error: No release found for tag ${process.env.TAG_NAME}. Please create it first.`);
-            }
-      # 使用现有 body 创建/更新 Release
       - name: Upload Release
-        if: steps.get_release.outputs.id
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ inputs.tag_name }}
-          name: ${{ inputs.tag_name }}
-          body: ${{ steps.get_release.outputs.body }}  # 使用获取到的现有 body
-          files: ${{ github.workspace }}/NepTrainKit.windows-x86_64.zip
-          draft: false
-          prerelease: false
+        shell: pwsh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ inputs.tag_name }}" "${{ github.workspace }}/NepTrainKit.windows-x86_64.zip" --repo "$env:GITHUB_REPOSITORY" --clobber

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -138,13 +138,19 @@ def test_macos_wheels_use_explicit_openmp_repair_and_portability_gate():
 
 
 def test_release_assets_are_uploaded_without_updating_release_metadata():
-    workflow = (
+    publish_workflow = (
         ROOT / ".github" / "workflows" / "python-publish.yml"
     ).read_text(encoding="utf-8")
+    nuitka_workflow = (
+        ROOT / ".github" / "workflows" / "Build-with-Nuitka.yml"
+    ).read_text(encoding="utf-8")
 
-    assert "softprops/action-gh-release" not in workflow
-    assert 'gh release upload "$RELEASE_TAG" dist/*' in workflow
-    assert '--repo "$GITHUB_REPOSITORY" --clobber' in workflow
+    assert "softprops/action-gh-release" not in publish_workflow
+    assert 'gh release upload "$RELEASE_TAG" dist/*' in publish_workflow
+    assert '--repo "$GITHUB_REPOSITORY" --clobber' in publish_workflow
+    assert "softprops/action-gh-release" not in nuitka_workflow
+    assert 'gh release upload "${{ inputs.tag_name }}"' in nuitka_workflow
+    assert '--repo "$env:GITHUB_REPOSITORY" --clobber' in nuitka_workflow
 
 
 def test_test_and_wheel_matrices_cover_documented_python_versions():


### PR DESCRIPTION
## 问题

Windows x86_64 Nuitka 编译、runtime health check、压缩与备份 Artifact 均成功，但最后使用 softprops/action-gh-release 更新已有 v3.0.1 release 时被 GitHub 拒绝。

## 修复

- 与 Python 发布 workflow 统一，改用 gh release upload --clobber
- 只上传独立包资产，不读取或改写已有 release 的标题和正文
- 显式保留 contents: write
- 扩展 packaging contract 覆盖两个 release workflow

## 验证

- packaging contract：15 passed
- 两个 workflow YAML 均解析通过
- git diff --check 通过