### PR TITLE
fix(ci): 修复 Windows 测试退出与 Nuitka 模板校验

### DIFF
--- a/.github/workflows/Build-with-Nuitka.yml
+++ b/.github/workflows/Build-with-Nuitka.yml
@@ -92,8 +92,27 @@ jobs:
           if (-not (Test-Path "$dist/translations/neptrainkit_zh_CN.qm")) {
             throw "Chinese translation catalog is missing from the standalone package."
           }
-          if (-not (Test-Path "$dist/workflow_templates/01_crystal_strain.json")) {
-            throw "Built-in workflow templates are missing from the standalone package."
+          $templateSource = "${{ github.workspace }}/src/NepTrainKit/workflow_templates"
+          $templateDestination = "$dist/workflow_templates"
+          $sourceTemplates = @(
+            Get-ChildItem -LiteralPath $templateSource -Filter "*.json" -File |
+              Select-Object -ExpandProperty Name |
+              Sort-Object
+          )
+          $packagedTemplates = @(
+            Get-ChildItem -LiteralPath $templateDestination -Filter "*.json" -File |
+              Select-Object -ExpandProperty Name |
+              Sort-Object
+          )
+          if ($sourceTemplates.Count -eq 0) {
+            throw "No built-in workflow template JSON files were found in the source package."
+          }
+          $templateDiff = Compare-Object `
+            -ReferenceObject $sourceTemplates `
+            -DifferenceObject $packagedTemplates
+          if ($templateDiff) {
+            $templateDiffText = ($templateDiff | Out-String).Trim()
+            throw "Built-in workflow templates differ between source and standalone package:`n$templateDiffText"
           }
           New-Item -ItemType Directory -Force "$dist/Log"
           New-Item -ItemType File -Path "$dist/Log/.placeholder" -Force

--- a/tests/cards/card_test_base.py
+++ b/tests/cards/card_test_base.py
@@ -194,12 +194,6 @@ class BaseCardTest(unittest.TestCase):
         cls.base_structure = read(cls.test_dir / "data" / "Si2.vasp")
         cls.base_structure.info.setdefault("Config_type", "Si2")
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls._app is not None:
-            cls._app.quit()
-            cls._app = None
-
     def setUp(self):
         np.random.seed(0)
         random.seed(0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,9 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+from PySide6.QtWidgets import QApplication
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_PATH = PROJECT_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
@@ -12,3 +15,19 @@ if str(SRC_PATH) not in sys.path:
 LOCALAPPDATA_PATH = Path(__file__).resolve().parent / "_localappdata"
 LOCALAPPDATA_PATH.mkdir(parents=True, exist_ok=True)
 os.environ["LOCALAPPDATA"] = str(LOCALAPPDATA_PATH)
+
+
+_TEST_QAPPLICATION: QApplication | None = None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _keep_qapplication_alive():
+    """Keep one process-wide QApplication alive for the full suite.
+
+    A number of unittest-style Qt suites share this application. Destroying it
+    between classes can make the Windows offscreen plugin exit non-zero after
+    an otherwise successful test run.
+    """
+    global _TEST_QAPPLICATION
+    _TEST_QAPPLICATION = QApplication.instance() or QApplication([])
+    yield _TEST_QAPPLICATION

--- a/tests/test_canvas_factory.py
+++ b/tests/test_canvas_factory.py
@@ -49,21 +49,7 @@ class _InverseSelectionData:
 class TestCanvasFactory(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls._app = QApplication.instance()
-        cls._owns_app = cls._app is None
-        if cls._owns_app:
-            cls._app = QApplication([])
-
-    @classmethod
-    def tearDownClass(cls):
-        # pytest-qt owns the process-wide QApplication in the full suite.  Do
-        # not quit it here: doing so leaves later Qt/pyqtgraph tests with a
-        # shut-down event dispatcher and can make the Windows runner return
-        # exit code 1 after an otherwise green test summary.
-        if cls._owns_app and cls._app is not None:
-            cls._app.quit()
-        cls._app = None
-        cls._owns_app = False
+        cls._app = QApplication.instance() or QApplication([])
 
     def test_create_result_canvas_pyqtgraph_default(self):
         canvas, fallback = canvas_factory.create_result_canvas(CanvasMode.PYQTGRAPH, None)

--- a/tests/test_card_library_dialog.py
+++ b/tests/test_card_library_dialog.py
@@ -25,12 +25,6 @@ class TestCardLibraryDialog(unittest.TestCase):
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls._app is not None:
-            cls._app.quit()
-            cls._app = None
-
     def test_library_search_filters_card_metadata(self):
         dialog = CardLibraryDialog()
         self.assertGreater(dialog.card_list.count(), 1)

--- a/tests/test_data_manager_ui.py
+++ b/tests/test_data_manager_ui.py
@@ -59,12 +59,6 @@ class TestDataManagerUi(unittest.TestCase):
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls._app is not None:
-            cls._app.quit()
-            cls._app = None
-
     def test_project_and_model_actions_are_visible_without_context_menu(self):
         with patch.object(project_view_module.QTimer, "singleShot"):
             project_widget = ProjectWidget()

--- a/tests/test_export_format_dialog.py
+++ b/tests/test_export_format_dialog.py
@@ -11,12 +11,6 @@ class TestExportFormatMessageBox(unittest.TestCase):
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls._app is not None:
-            cls._app.quit()
-            cls._app = None
-
     def setUp(self):
         self.parent = QWidget()
 

--- a/tests/test_makedata_export_scope.py
+++ b/tests/test_makedata_export_scope.py
@@ -32,12 +32,6 @@ class TestMakeDataExportScope(unittest.TestCase):
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls._app is not None:
-            cls._app.quit()
-            cls._app = None
-
     def test_default_export_selects_only_final_enabled_output(self):
         first = _card("first")
         disabled = _card("disabled", enabled=False)

--- a/tests/test_makedata_source_card.py
+++ b/tests/test_makedata_source_card.py
@@ -23,12 +23,6 @@ class TestMakeDataSourceCard(unittest.TestCase):
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls._app is not None:
-            cls._app.quit()
-            cls._app = None
-
     def test_run_source_card_without_input_dataset(self):
         widget = MakeDataWidget()
         widget.add_card("CrystalPrototypeBuilderCard")

--- a/tests/test_nep.py
+++ b/tests/test_nep.py
@@ -365,12 +365,6 @@ class TestNepResultPlotWidgetShiftEnergyBaseline(unittest.TestCase):
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls._app is not None:
-            cls._app.quit()
-            cls._app = None
-
     @staticmethod
     def _make_widget(data):
         widget = nep_view_module.NepResultPlotWidget.__new__(nep_view_module.NepResultPlotWidget)
@@ -771,12 +765,6 @@ class TestTrainingOverlayDialog(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls._app is not None:
-            cls._app.quit()
-            cls._app = None
 
     def test_dialog_uses_result_canvas_and_single_axis(self):
         from PySide6.QtWidgets import QWidget

--- a/tests/test_packaging_contract.py
+++ b/tests/test_packaging_contract.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 try:
@@ -94,7 +95,16 @@ def test_built_in_workflow_templates_are_packaged_for_wheels_and_nuitka():
 
     assert package_data["NepTrainKit.workflow_templates"] == ["*.json"]
     assert "src/NepTrainKit/workflow_templates" in workflow
-    assert "Built-in workflow templates are missing" in workflow
+    assert 'Get-ChildItem -LiteralPath $templateSource -Filter "*.json" -File' in workflow
+    assert 'Get-ChildItem -LiteralPath $templateDestination -Filter "*.json" -File' in workflow
+    assert "Compare-Object" in workflow
+    assert "-ReferenceObject $sourceTemplates" in workflow
+    assert "-DifferenceObject $packagedTemplates" in workflow
+    assert "Built-in workflow templates differ" in workflow
+    assert not re.findall(
+        r"workflow_templates[/\\][^\"'\s]+\.json",
+        workflow,
+    )
 
 
 def test_nuitka_build_validates_flat_standalone_layout():

--- a/tests/test_qapplication_lifecycle.py
+++ b/tests/test_qapplication_lifecycle.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_unittest_suites_do_not_quit_the_shared_qapplication():
+    """Prevent Windows Qt teardown failures after a green pytest summary."""
+    tests_root = Path(__file__).resolve().parent
+    offenders = []
+    for path in tests_root.rglob("*.py"):
+        if path == Path(__file__):
+            continue
+        text = path.read_text(encoding="utf-8-sig")
+        if "cls._app.quit()" in text:
+            offenders.append(str(path.relative_to(tests_root)))
+
+    assert offenders == []

--- a/tests/test_shift_energy_dialog.py
+++ b/tests/test_shift_energy_dialog.py
@@ -12,12 +12,6 @@ class TestShiftEnergyMessageBox(unittest.TestCase):
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls._app is not None:
-            cls._app.quit()
-            cls._app = None
-
     def setUp(self):
         self.parent = QWidget()
         self.parent.resize(640, 480)

--- a/tests/test_training_set_audit_integration.py
+++ b/tests/test_training_set_audit_integration.py
@@ -58,12 +58,6 @@ class TestTrainingSetAuditIntegration(unittest.TestCase):
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls._app is not None:
-            cls._app.quit()
-            cls._app = None
-
     def test_show_nep_select_structure_indices_replaces_selection(self):
         widget = ShowNepWidget.__new__(ShowNepWidget)
         widget.nep_result_data = SimpleNamespace(select_index={4, 5})

--- a/tests/test_training_set_audit_page.py
+++ b/tests/test_training_set_audit_page.py
@@ -45,12 +45,6 @@ class TestTrainingSetAuditWidget(unittest.TestCase):
     def setUpClass(cls):
         cls._app = QApplication.instance() or QApplication([])
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls._app is not None:
-            cls._app.quit()
-            cls._app = None
-
     @staticmethod
     def _histogram(plot_id, title):
         return {


### PR DESCRIPTION
## 变更

- 统一 pytest 进程中的 QApplication 生命周期，避免 Windows 在绿色摘要后异常退出
- 让 Nuitka 比较源码与 standalone 包中的全部内置模板，不再硬编码模板文件名
- 增加生命周期与打包契约回归测试

## 验证

- 本地完整测试：1490 passed
- 卡片快速检查：513 passed，44 张卡片文档与 operation 架构审计通过
- dev 完整 CI：通过（含 Windows Python 3.10）
- 打包契约测试：18 passed